### PR TITLE
Remove prepdocs.sh from list of scripts to run in pipeline

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -35,13 +35,13 @@ hooks:
     postprovision:
       windows:
         shell: pwsh
-        run: ./scripts/auth_update.ps1;./scripts/prepdocs.ps1; # Working run
+        run: ./scripts/auth_update.ps1;./scripts/prepdocs.ps1;
         interactive: true
         continueOnError: false
       posix:
         shell: sh
-        run: |
+        run: | # Remove prepdocs.sh since we create the index in create_aisearch_resources.sh
           chmod +x ./scripts/create_aisearch_resources.sh
-          ./scripts/auth_update.sh;./scripts/prepdocs.sh;./scripts/create_aisearch_resources.sh # Working run
+          ./scripts/auth_update.sh;./scripts/create_aisearch_resources.sh
         interactive: true
         continueOnError: false

--- a/infrastructure/deployment.json
+++ b/infrastructure/deployment.json
@@ -53,9 +53,9 @@
         },
         "AzureSearchIndex": {
             "type": "string",
-            "defaultValue": "newindex478902",
+            "defaultValue": "defaultindexname",
             "metadata": {
-                "description": "Name of Azure Search Index"
+                "description": "Name of Azure Search Index. This is used when an index name isn't provided in the deployment"
             }
         },
         "AzureSearchKey": {


### PR DESCRIPTION
The prepdocs.sh was being called in a postprovision hook in the azure.yaml file. This then ran the prepdocs.py file which was origianlly used to create the ai search index, chunk the source data and upload the data to the index. 

Since we now create and populate our own index (via create_aisearch_resources.sh), there is no need to run this script.